### PR TITLE
Add whitespace to fix malformed YAML

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -95,15 +95,15 @@ Follow these steps to create the IPsec manifest for your deployment:
             -----END RSA PRIVATE KEY-----
           <strong>ca\_certificates</strong>:
             \- |
-            -----BEGIN CERTIFICATE-----
-            MIIFCTCCAvGgAwIBAgIBATANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwl0ZXN0
-            ...
-            -----END CERTIFICATE-----
+              -----BEGIN CERTIFICATE-----
+              MIIFCTCCAvGgAwIBAgIBATANBgkqhkiG9w0BAQsFADAUMRIwEAYDVQQDEwl0ZXN0
+              ...
+              -----END CERTIFICATE-----
             \- |
-            -----BEGIN CERTIFICATE-----
-            MIIFCTCCAvGgAwIBAgIBATAAYDVQQDEwl0ZXN0NBgkqhkiG9w0BAQsFADAUMRIwE
-            ...
-            -----END CERTIFICATE-----
+              -----BEGIN CERTIFICATE-----
+              MIIFCTCCAvGgAwIBAgIBATAAYDVQQDEwl0ZXN0NBgkqhkiG9w0BAQsFADAUMRIwE
+              ...
+              -----END CERTIFICATE-----
           <strong>prestart\_timeout</strong>: 30 </pre>
 
 2. Replace the properties listed in the file as follows:


### PR DESCRIPTION
[#116930929] Add missing spaces to example runtime config in ipsec docs

Signed-off-by: Matthew Boedicker <mboedicker@pivotal.io>