### PR TITLE
Recommend different subnet for services.  Change OSI layer to 'network'

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -11,7 +11,7 @@ This guide describes the [Pivotal Cloud Foundry&reg;](https://network.pivotal.io
 
 ## Overview ##
 
-The IPsec add-on for PCF provides security to the transport layer of the OSI model with a [strongSwan](https://www.strongswan.org/) implementation of IPsec. The IPsec add-on provides a strongSwan job to each BOSH-deployed virtual machine (VM). 
+The IPsec add-on for PCF provides security to the network layer of the OSI model with a [strongSwan](https://www.strongswan.org/) implementation of IPsec. The IPsec add-on provides a strongSwan job to each BOSH-deployed virtual machine (VM). 
 
 IPsec encrypts IP data flow between hosts, between security gateways, and between security gateways and hosts. The PCF IPsec add-on secures network traffic within a Cloud Foundry deployment and provides internal system protection if a malicious actor breaches your firewall. 
 

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -20,6 +20,8 @@ To complete the IPsec installation, check that you have satisfied the following 
  the IPsec functionality. Pivotal recommends installing IPsec immediately after Ops Manager, and before installing the 
 Elastic Runtime tile. </p>
 
+<p class="note"><strong>Note</strong>: IPsec functionality has not been verified to not adversely affect the functioning for every available service tile.  For this reason. Pivotal recommends either deploying Elastic Runtime and each service to different isolated subnets, or minimally deploying all services to a single islolated subnet apart from the Elastic Runtime subnet.</p>
+
 <p class="note"><strong>Note</strong>: For IPsec, Pivotal recommends any Ubuntu stemcells for vSphere and HVM stemcells for AWS, which are available on <a href="https://network.pivotal.io/products/stemcells">Pivotal Network</a>. If you are using PV stemcells obtained from <a href="https://bosh.io">bosh.io</a>, see <a href="./troubleshooting.html#ipsec-installation-issues">Preventing Packet Loss</a> in the Troubleshooting topic to adjust MTU values.</p> 
 
 ##<a id="config-network"></a>Configure Network Security


### PR DESCRIPTION
1. Changed overview comment to indicate that IPsec encrypts at the network layer rather than the transport layer.
1. Added a note to recommend that services be deployed to different subnet(s) than ERT - might require some word-smithing.