### PR TITLE
1.7 config update

### DIFF
--- a/credentials.html.md.erb
+++ b/credentials.html.md.erb
@@ -10,65 +10,58 @@ This topic describes the process Pivotal recommends to increase deployment secur
 There are two procedures for credential rotation described in this topic.
 
 * [Procedure 1](#rotate-cert) describes rotating the following credentials specified in your IPsec manifest: 
-  * **For Linux VMs**: The instance certificate and instance private key 
-  * **For Windows VMs**: The instance PFX  <br><br>
+  * The instance certificate and instance private key 
   This procedure requires updating BOSH. It does not include rotating the certificate authority (CA) certificate. 
 
-* [Procedure 2](#rotate-CA) describes rotating your CA certificate in addition to your instance certificate, instance private key, and instance PFX. This procedure requires updating BOSH three times.
+* [Procedure 2](#rotate-CA) describes rotating your CA certificate in addition to your instance certificate and instance private key. This procedure requires updating BOSH three times.
 
 <p class="note"><strong>Note</strong>: The rolling deploys during these procedures result in minimal deployment downtime.</p>
 
-## <a id="rotate-cert"></a>Procedure 1: Rotate the Instance Certificate, Instance Private Key, and (Windows )Instance PFX
+## <a id="rotate-cert"></a>Procedure 1: Rotate the Instance Certificate and Instance Private Key
 
-Follow the steps below to rotate the instance certificate, instance private key, and, if your IPsec deployment supports Windows, the instance PFX.
+Follow the steps below to rotate the instance certificate and instance private key.
 
 1. Generate a new certificate and use your existing IPsec CA certificate to sign the new certificate.
 
 1. Update the instance certificate and the private key fields in your `ipsec-addon.yml` file with new values from the previous step.
 
-1. If your IPsec deployment supports Windows, generate a new PFX file using the key and certificate from the previous step.
-  1. Update the `instance_pfx` field in your `ipsec-addon.yml` with the contents of the new PFX you generated. 
-
-3. Run the following command:
+1. Run the following command:
   <pre class="terminal">
   $ bosh update runtime-config PATH/MYPRODUCT_ipsec-addon.yml
   </pre>
 <p class="note"><strong>Note</strong>: The following step results in a few minutes of application downtime. </p>
 
-4. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**. 
+1. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**. 
 
-## <a id="rotate-CA"></a>Procedure 2: Rotate the CA Certificate, the Instance Certificate, Instance Private Key, and (Windows) Instance PFX
+## <a id="rotate-CA"></a>Procedure 2: Rotate the CA Certificate, the Instance Certificate, and Instance Private Key
 
-Follow these steps to rotate the CA certificate, instance certificate, instance private key, and, if your IPsec deployment supports Windows, the instance pfx.
+Follow these steps to rotate the CA certificate, instance certificate, and instance private key.
 
 1. Generate a new CA certificate.
 
-2. Append the newly generated CA certificate under the existing certificate in your `ipsec-addon.yml`.
+1. Append the newly generated CA certificate under the existing certificate in your `ipsec-addon.yml`.
 
-3. Run the following command:
+1. Run the following command:
   <pre class="terminal">$ bosh update runtime-config PATH/MYPRODUCT_ipsec-addon.yml</pre>
 <p class="note"><strong>Note</strong>: The following step results in a few minutes of application downtime. </p>
 
-4. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
+1. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
 
-5. Generate a new certificate and use your new CA certificate to sign the new certificate.
+1. Generate a new certificate and use your new CA certificate to sign the new certificate.
 
-6. Update the instance certificate and the private key fields in the your `ipsec-addon.yml` file with new values from above. </p>
+1. Update the instance certificate and the private key fields in the your `ipsec-addon.yml` file with new values from above. </p>
 
-7. If your IPsec deployment supports Windows, generate a new PFX file (Base 64 encoded ) using the key and certificate from the previous step.
-  1. Update the `instance_pfx` field in your `ipsec-addon.yml` with the contents of the new PFX you generated. 
-
-7. Run the following command:
+1. Run the following command:
   <pre class="terminal">$ bosh update runtime-config PATH/MYPRODUCT_ipsec-addon.yml</pre>
 <p class="note"><strong>Note</strong>: The following step results in a few minutes of application downtime. </p>
 
-8. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
+1. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
 
-9. Delete the older CA certificate in the `ipsec-addon.yml` file.
+1. Delete the older CA certificate in the `ipsec-addon.yml` file.
 
-10. Run the following command:
+1. Run the following command:
   <pre class="terminal">$ bosh update runtime-config PATH/MYPRODUCT_ipsec-addon.yml</pre>
 <p class="note"><strong>Note</strong>: The following step results in a few minutes of application downtime. </p>
 
-11. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
+1. Navigate to your Ops Manager interface in a browser, and click **Apply Changes**.
 

--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -283,9 +283,16 @@ Follow these steps if you want to add IPsec to Windows VMs in your deployment.
           <strong>no\_ipsec\_subnets</strong>:
           \- 10.0.1.10/32  # bosh director
           \- 10.0.1.4/32 # ops manager
-          <strong>instance\_pfx</strong>: |
+          <strong>instance\_certificate</strong>: |
+            -----BEGIN CERTIFICATE-----
             MIIEMDCCAhigAwIBAgIRAIvrBY2TttU/LeRhO+V1t0YwDQYJKoZIhvcNAQELBQAw
             ...
+            -----END CERTIFICATE-----
+          <strong>instance\_private\_key</strong>: |
+            -----BEGIN RSA PRIVATE KEY-----
+            EXAMPLExRSAxPRIVATExKEYxDATAxEXAMPLExRSAxPRIVATExKEYxDATA
+            ...
+            -----END RSA PRIVATE KEY-----
           <strong>ca\_certificates</strong>:
             \- |
               -----BEGIN CERTIFICATE-----
@@ -311,11 +318,8 @@ Follow these steps if you want to add IPsec to Windows VMs in your deployment.
    * <code>include: stemcell - os</code>: IPsec for Windows is only supported on `windows2012R2`.
    * <code>ipsec\_subnets</code>: Copy and paste the value from [ipsec\_subnets](#ipsec_subnets) for Linux.
    * <code>no\_ipsec\_subnets</code>: Copy and paste the value from [no\_ipsec\_subnets](#no_ipsec_subnets) for Linux.
-   * <code>instance\_pfx</code>: In PFX format (Base64 encoded), enter the signed [instance\_certificate](#instance_certificate) and corresponding [instance\_private_key](#instance_private_key) that you specified for Linux. You can generate this PFX file using your certificate and key as input with the following commands:
-     <pre class="terminal">
-      $ openssl pkcs12 -export -out pcf-ipsec-peer.pfx -inkey YOUR-IPSEC-INSTANCE-PRIVATE-KEY.pem -in YOUR-IPSEC-INSTANCE-CERTIFICATE.pem
-      $ base64 -b 64 -i pcf-ipsec-peer.pfx -o pcf-ipsec-peer.pfx.b64
-     </pre>
+   * <code>instance\_certificate</code>: Copy and paste the value from [instance\_certificate](#instance_certificate) for Linux.
+   * <code>instance\_private\_key</code>: Copy and paste the value from [instance\_private\_key](#instance_private_key) for Linux.
    * <code>ca\_certificates</code>: Copy and paste the value from [ca\_certificates](#ca_certificates) for Linux.
    * <code>optional</code>: Copy and paste the value from [optional](#optional) for Linux.
    * <code>quick\_mode\_proposals</code>: Array of Quick Mode algorithms for encryption and integrity. This value must match the list specified in [esp_proposals](#esp_proposals) for Linux. See the following default entry that matches the Linux default:

--- a/scripts/openssl-create-ipsec-certs.sh
+++ b/scripts/openssl-create-ipsec-certs.sh
@@ -54,8 +54,6 @@ openssl req -newkey rsa:2048 -days 365 -nodes -sha256 -subj /CN=PCF\ IPsec\ peer
 openssl x509 -req -in pcf-ipsec-peer-req.pem -days 365 -extfile openssl.cnf -extensions v3_req -CA pcf-ipsec-ca-cert.pem -CAkey pcf-ipsec-ca-key.pem -set_serial 01 -out pcf-ipsec-peer-cert.pem
 openssl x509 -inform pem -in pcf-ipsec-peer-cert.pem -text
 openssl x509 -inform pem -in pcf-ipsec-ca-cert.pem  -text
-openssl pkcs12 -export -out pcf-ipsec-peer.pfx -inkey pcf-ipsec-peer-key.pem -in pcf-ipsec-peer-cert.pem
-base64 -b 64 -i pcf-ipsec-peer.pfx -o pcf-ipsec-peer.pfx.b64
 
 rm -f openssl.cnf
 rm -f pcf-ipsec-peer-req.pem


### PR DESCRIPTION
We no longer need `instance_pfx` for Windows, we can use `instance_certificate` and `instance_private_key` like Linux.