### PR TITLE
fix the link to azure load balancer

### DIFF
--- a/troubleshooting.html.md.erb
+++ b/troubleshooting.html.md.erb
@@ -329,4 +329,4 @@ Do not use Network Load Balancers as your external load balancer in your IaaS. U
 
 * For GCP, see <a href="https://cloud.google.com/load-balancing/docs/https/setting-up-https">the Google Cloud documentation</a>.
 
-* For Azure, see <a href="https://cloud.google.com/load-balancing/docs/https/setting-up-https">Setup an application gateway</a>
+* For Azure, see <a href="https://azure.microsoft.com/en-ca/services/application-gateway">Setup an application gateway</a>


### PR DESCRIPTION
Signed-off-by: Carl He <jhe@pivotal.io>

Yeah, just address the issue for the wrong link. and cherry pick it 1.9