### PR TITLE
Add release notes for IPsec 1.9.19 [#167734791]

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -28,19 +28,19 @@ The following table provides version and version-support information about the I
     <th>Details</th>
     <tr>
         <td>Version</td>
-        <td>v1.9.13</td>
+        <td>v1.9.19</td>
     </tr>
     <tr>
         <td>Release date</td>
-        <td>November 19, 2018</td>
+        <td>August 26, 2019</td>
     </tr>
     <tr>
         <td>Compatible Ops Manager versions</td>
-        <td>2.2, 2.3, 2.4, and 2.5</td>
+        <td>2.3, 2.4, 2.5, and 2.6</td>
     </tr>
     <tr>
         <td>Compatible Pivotal Application Service (PAS) versions</td>
-        <td>2.2, 2.3, 2.4, and 2.5</td>
+        <td>2.3, 2.4, 2.5, and 2.6</td>
     </tr>
     <tr>
         <td>Compatible BOSH stemcells</td>

--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -7,6 +7,21 @@ owner: Security Engineering
 
 This topic contains release notes for the IPsec Add-on for PCF.
 
+##<a id="1919"></a>  v1.9.19
+
+**Release Date:** August 26, 2019
+
+### Features
+
+New features and changes in this release:
+
+* Updates strongSwan to v5.8.0.
+  See the [strongSwan v5.8.0 release notes](https://www.strongswan.org/blog/2019/05/20/strongswan-5.8.0-released.html).
+
+### Known Issues
+
+There are no known issues for this release.
+
 ##<a id="1913"></a>  v1.9.13
 
 **Release Date:** November 19, 2018


### PR DESCRIPTION
In the release notes section, I took out the "Fixes" section.