### PR TITLE
Remove product Snapshot session

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -22,40 +22,6 @@ It provides a strongSwan job in FIPS mode to each BOSH-deployed VM.
 It secures network traffic within a Cloud Foundry deployment
 and provides internal system protection if a malicious actor breaches your firewall.
 
-## <a id='snapshot'></a> Product Snapshot
-
-The following table provides version and version-support information about <%= vars.product_full %>.
-
-<table class="nice">
-    <th>Element</th>
-    <th>Details</th>
-    <tr>
-        <td>Version</td>
-        <td>v1.9.35</td>
-    </tr>
-    <tr>
-        <td>Release date</td>
-        <td>April 9, 2021</td>
-    </tr>
-    <tr>
-        <td>Compatible <%= vars.ops_manager_full %> versions</td>
-        <td>2.10, 2.9, and 2.8</td>
-    </tr>
-    <tr>
-        <td>Compatible <%= vars.app_runtime_full %>  versions</td>
-        <td>2.11, 2.10, 2.9, and 2.8</td>
-    </tr>
-    <tr>
-        <td>Compatible BOSH stemcells</td>
-        <td>Ubuntu Xenial and Trusty</td>
-    </tr>
-    <tr>
-        <td>IaaS support</td>
-        <td>vSphere, GCP, AWS, Azure, and Openstack</td>
-    </tr>
-</table>
-
-
 ## <a id="implementation"></a> <%= vars.product_short %> Implementation Details
 
 <%= vars.product_full %> implements the following cryptographic suite:


### PR DESCRIPTION
Hi team,

I'd like to start a conversations as to whether we could remove the Product Snapshot session from the docs.

We already have all that information on Pivnet: https://network.pivotal.io/products/p-ipsec-addon#

I wonder whether there's any value in keeping this information in both places, knowing every time we release we have to update the session manually, which can be error prone and takes time.