### PR TITLE
Update install instructions for swanctl vs ipsec

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -674,12 +674,51 @@ After installing <%= vars.product_short %> and deploying <%= vars.app_runtime_ab
     </pre>
 
 
-1. Confirm that <%= vars.product_short %> is running. If <%= vars.product_short %> is not running, this command produces no output.
+1. Confirm that <%= vars.product_short %> is running. If <%= vars.product_short %> is running, the following commands will provide uptime and connections information:
 
-    ```
-    PATH-TO-IPSEC/ipsec statusall
-    ```
+    - `swanctl --stats`
+    - `swanctl --list-conns
+
     For example:
+    <pre class="terminal">
+    $ /var/vcap/packages/strongswan/sbin/swanctl --stats
+    plugin 'openssl' failed to load: libcrypto.so.1.0.2: cannot open shared object file: No such file or directory
+    uptime: 79 minutes, since Feb 17 16:25:20 2023
+    worker threads: 16 total, 11 idle, working: 4/0/1/0
+    job queues: 0/0/0/0
+    jobs scheduled: 12
+    IKE_SAs: 4 total, 0 half-open
+    mallinfo: sbrk 2494464, mmap 0, used 797184, free 1697280
+    loaded plugins: charon aes sha1 sha2 random nonce x509 revocation constraints pubkey pkcs1 pkcs7 pkcs8 pkcs12 pem gmp xcbc cmac hmac attr kernel-netlink socket-default vici openssl
+
+    $ /var/vcap/packages/strongswan/sbin/swanctl --list-conns
+    plugin 'openssl' failed to load: libcrypto.so.1.0.2: cannot open shared object file: No such file or directory
+    ipsec: IKEv2, no reauthentication, rekeying every 14400s, dpd delay 10s
+      local:  10.0.4.8/32
+      remote: 10.0.0.0/8
+      local public key authentication:
+        id: CN=ipsec_addon_instance_cert_1
+        certs: CN=ipsec_addon_instance_cert_1
+      remote public key authentication:
+      ipsec: TRANSPORT, rekeying every 3600s, dpd action is restart
+        local:  10.0.4.8/32
+        remote: 10.0.0.0/8
+    no-ipsec: IKEv1/2, no reauthentication, rekeying every 14400s
+      local:  10.0.4.8/32
+      remote: 10.0.8.0/24
+      remote: 10.0.0.5/32
+      remote: 10.0.0.2/32
+      remote: 10.0.12.0/24
+      local unspecified authentication:
+      remote unspecified authentication:
+      no-ipsec: PASS, no rekeying
+        local:  10.0.4.8/32
+        remote: 10.0.8.0/24 10.0.0.5/32 10.0.0.2/32 10.0.12.0/24
+    $
+    </pre>
+
+    Note that before <%= vars.product_short %> version 1.9.40, the appropriate command was `PATH-TO-IPSEC/ipsec statusall`. For example:
+
     <pre class="terminal">
     $ /var/vcap/packages/strongswan-5.6.3/sbin/ipsec statusall
     Status of IKE charon daemon (strongSwan 5.6.3, Linux 3.19.0-56-generic, x86\_64):


### PR DESCRIPTION
When we released version 1.9.40 of the ipsec-release bosh addon, we changed the internal command used to create the secure network. We changed from using the `ipsec` command, to using the `swanctl` command (both of which are provided by the `strongswan` software package).

As a result, the command that users should use to check if their installation is working has also changed. Previously it was `ipsec statusall`. Now it is either or both of `swanctl --stats` or `swanctl --list-conns`.

This change updates the docs to assume we're using >= 1.9.40, and instruct the user to use `swanctl`. For users who find themselves reading recent docs while debugging older systems (or scripts that were written for older systems), we retain a note about the old way of doing things.

# References

Tracker story [#184475207](https://www.pivotaltracker.com/story/show/184475207)

See also [this JIRA](https://pivotal-io.atlassian.net/browse/PLATSEC-30), in which a customer tripped over this issue.

# Which other branches should this be merged with (if any)?

Branch `1.9`. I have already cherry-picked this PR to that branch, and opened PR #133 for it.