### PR TITLE
Fix error in runtime config; add jammy; remove trusty

### DIFF
--- a/installing.html.md.erb
+++ b/installing.html.md.erb
@@ -307,8 +307,8 @@ YAML:
             instance_certificate_critical_period: 3
       include:
         stemcell:
-        - os: ubuntu-trusty
-        - openssl: ubuntu-xenial
+        - os: ubuntu-xenial
+        - os: ubuntu-jammy
   ```
 
 1. Replace the values listed in the template above as follows:


### PR DESCRIPTION
`openssl` is not a valid key for stemcell include rules. Also, trusty stemcells are out of support and jammy stemcells are now supported.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

Just this one.

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see the repository README file.
