### PR TITLE
reflect 3.0.9 certification in docs starting with release 1.9.56

### DIFF
--- a/index.html.md.erb
+++ b/index.html.md.erb
@@ -87,7 +87,8 @@ The following table provides version and version-support information about <%= v
 </tr>
 <tr>
   <th>FIPS</th>
-  <td>FIPS Module OpenSSL 3.0.8 - <a href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282">certificate</a>
+  <td>Releases > `1.9.55` of  <%= vars.product_short %> use FIPS Module OpenSSL 3.0.9 - <a href="https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282">certificate</a>
+
 </tr>
 </table>
 


### PR DESCRIPTION
3.0.9 got validated and the next release will ship 3.0.9 version of the FIPS module.

# Which other branches do you want a technical writer to cherry-pick this PR to (if any)?

It's best to PR to the most recent relevant branch and leave all the cherry-picking to the
writer, except where earlier branches require factual changes to the content.
For more information about the branches, see the repository README file.
